### PR TITLE
Fix slow pattern for identifying JS script versions

### DIFF
--- a/telegram.lua
+++ b/telegram.lua
@@ -848,7 +848,7 @@ wget.callbacks.write_to_warc = function(url, http_stat)
         to_queue["https://t.me/" .. item_channel .. "/" .. id .. "?embed=1"] = true
       end
     end
-    for js_name, version in string.gmatch(html, "([^/]+%.js)%?([0-9]+)") do
+    for js_name, version in string.gmatch(html, "/([^/]+%.js)%?([0-9]+)") do
       if current_js[js_name] ~= version then
         io.stdout:write("Script " .. js_name .. " with version " .. version .. " is not known.\n")
         io.stdout:flush()


### PR DESCRIPTION
telegram-grab currently uses a ton of CPU on my servers, so I've done some profiling and this appears to be the cause. Adding an explicit `/` before the rest of the pattern allows the search to be much quicker, since it removes the need for backtracking (thus limiting the search to O(n) instead of O(n^2): https://regex101.com/r/U3F52T/1/debugger).

Tested locally with a `wget-at` call taken from a live warrior instance. Also checked that the scripts on the page are still identified correctly.

Output from `time wget-at ...` before this change:
`2.74user 0.02system 0:06.03elapsed 45%CPU (0avgtext+0avgdata 8864maxresident)k`

Output from `time wget-at ...` after this change:
`0.06user 0.00system 0:02.04elapsed 3%CPU (0avgtext+0avgdata 8932maxresident)k`