### PR TITLE
use https for all AT services

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -73,7 +73,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20241119.01'
+VERSION = '20241127.01'
 USER_AGENT = 'Archive Team'
 TRACKER_ID = 'telegram'
 TRACKER_HOST = 'legacy-api.arpa.li'

--- a/pipeline.py
+++ b/pipeline.py
@@ -339,14 +339,14 @@ project = Project(
     title='Telegram',
     project_html='''
         <img class="project-logo" alt="Project logo" src="https://wiki.archiveteam.org/images/thumb/7/7d/Telegram-icon.png/600px-Telegram-icon.png" height="50px" title=""/>
-        <h2>telegram.org <span class="links"><a href="https://telegram.org/">Website</a> &middot; <a href="http://tracker.archiveteam.org/telegram/">Leaderboard</a></span></h2>
+        <h2>telegram.org <span class="links"><a href="https://telegram.org/">Website</a> &middot; <a href="https://tracker.archiveteam.org/telegram/">Leaderboard</a></span></h2>
         <p>Archiving public Telegram channels.</p>
     '''
 )
 
 pipeline = Pipeline(
     CheckIP(),
-    GetItemFromTracker('http://{}/{}/multi={}/'
+    GetItemFromTracker('https://{}/{}/multi={}/'
         .format(TRACKER_HOST, TRACKER_ID, MULTI_ITEM_SIZE),
         downloader, VERSION),
     PrepareDirectories(warc_prefix=TRACKER_ID),
@@ -374,7 +374,7 @@ pipeline = Pipeline(
         name='shared:rsync_threads', title='Rsync threads',
         description='The maximum number of concurrent uploads.'),
         UploadWithTracker(
-            'http://%s/%s' % (TRACKER_HOST, TRACKER_ID),
+            'https://%s/%s' % (TRACKER_HOST, TRACKER_ID),
             downloader=downloader,
             version=VERSION,
             files=[
@@ -392,7 +392,7 @@ pipeline = Pipeline(
         ),
     ),
     MaybeSendDoneToTracker(
-        tracker_url='http://%s/%s' % (TRACKER_HOST, TRACKER_ID),
+        tracker_url='https://%s/%s' % (TRACKER_HOST, TRACKER_ID),
         stats=ItemValue('stats')
     )
 )


### PR DESCRIPTION
https was used inconsistently for links (especially to the tracker)